### PR TITLE
fixing ignore message which apparently changed in phpstan release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "diablomedia/zendframework1-exception": "^1.0.0",
         "diablomedia/zendframework1-cache": "^1.0.0",
         "diablomedia/zendframework1-loader": "^1.0.0",
-        "diablomedia/zendframework1-locale": "^1.0.0"
+        "diablomedia/zendframework1-locale": "^1.0.3"
     },
     "autoload": {
         "psr-0": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 parameters:
+    inferPrivatePropertyTypeFromConstructor: true
     level: 2
     paths:
         - ./
@@ -53,7 +54,7 @@ parameters:
             message: '#Binary operation "\+=" between float\|int\|string and string results in an error\.#'
             path: %currentWorkingDirectory%/src/Zend/Date.php
         -
-            message: '#Binary operation "-" between string and int\|string results in an error\.#'
+            message: '#Binary operation "-" between string and \(int\|string\) results in an error\.#'
             path: %currentWorkingDirectory%/src/Zend/Date.php
         -
             message: '#Comparison operation ">" between int\|string\|Zend_Date and 0 results in an error\.#'


### PR DESCRIPTION
Also adding private property inference setting that was suggested by this version of phpstan (didn't end up alerting about any other errors in this component, but it is only level 2).